### PR TITLE
Add `min` and `max` validation in `TTY::Prompt::MultiList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## [Unreleased]
+* Add validation to ensure min is less than or equal to max in #multi_select
+
 ## [v0.23.1] - 2021-04-17
 
 ### Changed

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -23,6 +23,7 @@ module TTY
         @echo = options.fetch(:echo, true)
         @min  = options[:min]
         @max  = options[:max]
+        validate_min_max
       end
 
       # Set a minimum number of choices
@@ -30,6 +31,7 @@ module TTY
       # @api public
       def min(value)
         @min = value
+        validate_min_max
       end
 
       # Set a maximum number of choices
@@ -37,6 +39,7 @@ module TTY
       # @api public
       def max(value)
         @max = value
+        validate_min_max
       end
 
       # Callback fired when enter/return key is pressed
@@ -45,7 +48,7 @@ module TTY
       def keyenter(*)
         valid = true
         valid = @min <= @selected.size if @min
-        valid = @selected.size <= @max if @max
+        valid &= @selected.size <= @max if @max
 
         super if valid
       end
@@ -218,6 +221,19 @@ module TTY
         end
 
         output.join
+      end
+
+      # Validate min and max requirements are within bounds
+      #
+      # @raise [ConfigurationError]
+      #   raised when min is greater than max
+      #   or when min is less than available choices
+      #
+      # @api private
+      def validate_min_max
+        return unless @min && @max && @min > @max
+
+        raise ConfigurationError, "min cannot be greater than max"
       end
     end # MultiList
   end # Prompt


### PR DESCRIPTION
### Describe the change
- Add a `MultiList#validate_min_max` method to ensure `min` is less than or equal to `max`
- Call `validate_min_max` during initialization and when setting `min` and `max` values
- Update `MultiList#keyenter` to check both `min` and `max` constraints are satisfied on selection
- Update `output_helper` method in `multi_select_spec.rb` to support both `min` and `max` help text

### Why are we doing this?
This PR introduces validation logic to ensure that the `min` value is less than or equal to the `max` value in the `TTY::Prompt::MultiList` class. This would close #172 and #173.

### Benefits
This change prevents invalid configurations and ensures that the selection constraints are properly enforced.

### Drawbacks
Possible drawbacks applying this change.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [X] Documentation updated?
- [X] Changelog updated?
